### PR TITLE
Clean separation of generic and Android specific code

### DIFF
--- a/imagefilters.android.js
+++ b/imagefilters.android.js
@@ -1,0 +1,499 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var color_1 = require("tns-core-modules/color");
+var image_source_1 = require("tns-core-modules/image-source");
+var ImageProcessor = com.mukesh.image_processing.ImageProcessor;
+var ImageFilters = (function () {
+    function ImageFilters() {
+        this._processor = new ImageProcessor();
+    }
+    ImageFilters.prototype._getBitmap = function (img) {
+        var originalBitmap = img.android
+            .getDrawable()
+            .getBitmap();
+        return originalBitmap;
+    };
+    ImageFilters.prototype.highlightImage = function (img, color, radius) {
+        var _this = this;
+        if (radius === void 0) { radius = 5; }
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !color) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.doHighlightImage(_this._getBitmap(img), radius, new color_1.Color(color).android);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.invert = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image argument is required");
+                }
+                var bmp = _this._processor.doInvert(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.blackAndWhite = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.doGreyScale(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.gamma = function (img, red, green, blue) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !red || !green || !blue) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.doGamma(_this._getBitmap(img), red, green, blue);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.colorFilter = function (img, red, green, blue) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !red || !green || !blue) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.doColorFilter(_this._getBitmap(img), red, green, blue);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.sepiaEffect = function (img, depth, red, green, blue) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !depth || !red || !green) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.createSepiaToningEffect(_this._getBitmap(img), depth, red, green, blue);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.decreaseColorDepth = function (img, bitOffset) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !bitOffset) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.decreaseColorDepth(_this._getBitmap(img), bitOffset);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.contrast = function (img, value) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !value) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.createContrast(_this._getBitmap(img), value);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.rotate = function (img, degree) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !degree) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.createContrast(_this._getBitmap(img), degree);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.brightness = function (img, value) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !value) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.createContrast(_this._getBitmap(img), value);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.gaussianBlur = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.applyGaussianBlur(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.createShadow = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.createShadow(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.sharpen = function (img, weight) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !weight) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.sharpen(_this._getBitmap(img), weight);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.meanRemoval = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.applyMeanRemoval(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.smooth = function (img, value) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !value) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.smooth(_this._getBitmap(img), value);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.emboss = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.emboss(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.engrave = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.engrave(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.boost = function (img, type, percent) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !type || !percent) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.boost(_this._getBitmap(img), type, percent);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.roundCorner = function (img, round) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !round) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.roundCorner(_this._getBitmap(img), round);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.waterMark = function (img, watermark, location, color, alpha, size, underline) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !watermark) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.waterMark(_this._getBitmap(img), watermark, location, color, alpha, size, underline);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.flip = function (img, type) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !type) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.flip(_this._getBitmap(img), type);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.tintImage = function (img, degree) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !degree) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.tintImage(_this._getBitmap(img), degree);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.fleaEffect = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.applyFleaEffect(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.blackFilter = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.applyBlackFilter(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.snowEffect = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.applySnowEffect(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.shadingFilter = function (img, shadingColor) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !shadingColor) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.applyShadingFilter(_this._getBitmap(img), shadingColor);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.saturationFilter = function (img, level) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !level) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.applySaturationFilter(_this._getBitmap(img), level);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.hueFilter = function (img, level) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !level) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.applyHueFilter(_this._getBitmap(img), level);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.reflection = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img) {
+                    reject("Image is required");
+                }
+                var bmp = _this._processor.applyReflection(_this._getBitmap(img));
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    ImageFilters.prototype.replaceColor = function (img, fromColor, targetColor) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                if (!img || !fromColor || !targetColor) {
+                    reject("Missing required arguments");
+                }
+                var bmp = _this._processor.replaceColor(_this._getBitmap(img), new color_1.Color(fromColor).android, new color_1.Color(targetColor).android);
+                var isrc = image_source_1.fromNativeSource(bmp);
+                resolve(isrc);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    };
+    return ImageFilters;
+}());
+exports.ImageFilters = ImageFilters;

--- a/imagefilters.ios.js
+++ b/imagefilters.ios.js
@@ -1,0 +1,598 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var image_source_1 = require("tns-core-modules/image-source");
+var ImageFilters = (function () {
+    function ImageFilters() {
+        this._context = new CIContext(null);
+    }
+    ImageFilters.prototype.sepiaEffect = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 0.5; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CISepiaTone", inputImage);
+                filter.setValueForKey(intensity, kCIInputIntensityKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (ex) {
+                reject(ex);
+            }
+        });
+    };
+    ImageFilters.prototype.gamma = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIGammaAdjust", inputImage);
+                filter.setValueForKey(intensity, kCIInputBoostKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.invert = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIColorInvert", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.chromeEffect = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPhotoEffectChrome", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.fadeEffect = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPhotoEffectFade", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.vintage = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPhotoEffectInstant", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.colorize = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIColorMonochrome", inputImage);
+                filter.setValueForKey(intensity, kCIInputIntensityKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.motionBlur = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIMotionBlur", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.comicBook = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIComicEffect", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.crystalize = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CICrystallize", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.colorEdges = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIEdges", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.coloringBook = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIEdgeWork", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.dull = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIGloom", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.threeD = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIHeightFieldFromMask", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.sketch = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CILineOverlay", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.pointillize = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPointillize", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.spotLight = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CISpotLight", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.kaleidoscope = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIKaleidoscope", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.opTile = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIOpTile", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.perspectiveTile = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPerspectiveTile", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.twirl = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CITwirlDistortion", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.exposure = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIExposureAdjust", inputImage);
+                filter.setValueForKey(intensity, kCIInputEVKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.brightness = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIColorControls", inputImage);
+                filter.setValueForKey(intensity, kCIInputBrightnessKey);
+                filter.setValueForKey(1.05, kCIInputContrastKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.vibrant = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIColorControls", inputImage);
+                filter.setValueForKey(intensity * 2, kCIInputSaturationKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.gaussianBlur = function (img, radius) {
+        var _this = this;
+        if (radius === void 0) { radius = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIGaussianBlur", inputImage);
+                filter.setValueForKey(radius, kCIInputRadiusKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.blackAndWhite = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPhotoEffectMono", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.tonalEffect = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPhotoEffectTonal", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.circularWrap = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CICircularWrap", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.holeDistort = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIHoleDistortion", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.lightTunnel = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CILightTunnel", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.pinchDistort = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIPinchDistortion", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.torusLensDistort = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CITorusLensDistortion", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.vortexDistort = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIVortexDistortion", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.circularScreen = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CICircularScreen", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.halftone = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CICMYKHalftone", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.lineScreen = function (img) {
+        var _this = this;
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CILineScreen", inputImage);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.contrast = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIColorControls", inputImage);
+                filter.setValueForKey(intensity * 4, kCIInputContrastKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.sharpen = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CISharpenLuminance", inputImage);
+                filter.setValueForKey(intensity, kCIInputSharpnessKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype.posterize = function (img, intensity) {
+        var _this = this;
+        if (intensity === void 0) { intensity = 1; }
+        return new Promise(function (resolve, reject) {
+            try {
+                var inputImage = _this._createCGImage(img);
+                var filter = _this._createFilter("CIColorPosterize", inputImage);
+                filter.setValueForKey(intensity, kCIInputIntensityKey);
+                var result = _this._processImage(filter);
+                resolve(result);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    };
+    ImageFilters.prototype._createCGImage = function (img) {
+        var cgImg = CIImage.alloc().initWithCGImage(img.ios.image.CGImage);
+        return cgImg;
+    };
+    ImageFilters.prototype._createOutputCGImage = function (img) {
+        var outputCGImage = this._context.createCGImageFromRect(img, img.extent);
+        return outputCGImage;
+    };
+    ImageFilters.prototype._createFilter = function (name, img) {
+        var filter = CIFilter.filterWithName(name);
+        filter.setValueForKey(img, kCIInputImageKey);
+        filter.setDefaults();
+        return filter;
+    };
+    ImageFilters.prototype._processImage = function (filter) {
+        var filteredImg = filter.valueForKey(kCIOutputImageKey);
+        var outputCGImage = this._createOutputCGImage(filteredImg);
+        var outputUIImage = UIImage.imageWithCGImage(outputCGImage);
+        var result = image_source_1.fromNativeSource(outputUIImage);
+        return result;
+    };
+    return ImageFilters;
+}());
+exports.ImageFilters = ImageFilters;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="node_modules/tns-platform-declarations/android.d.ts" />
 import { Image } from "tns-core-modules/ui/image";
 import { ImageSource } from "tns-core-modules/image-source";
 export declare class ImageFilters {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="node_modules/tns-platform-declarations/android.d.ts" />
 import { Image } from "tns-core-modules/ui/image";
 import { ImageSource } from "tns-core-modules/image-source";
 export declare class ImageFilters {

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export declare class ImageFilters {
   waterMark(
     img: Image,
     watermark: string,
-    location: android.graphics.Point,
+    location: Point,
     color: number,
     alpha: number,
     size: number,
@@ -67,4 +67,9 @@ export declare class ImageFilters {
     fromColor: string,
     targetColor: string
   ): Promise<ImageSource>;
+}
+
+declare class Point {
+	x: number;
+	y: number;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,735 @@
+{
+  "name": "nativescript-image-filters",
+  "version": "2.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "ci-info": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+      "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "js-yaml": "3.11.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "require-from-string": "1.2.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "husky": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.4.tgz",
+      "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "find-parent-dir": "0.3.0",
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0"
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.3"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "lint-staged": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-3.6.1.tgz",
+      "integrity": "sha1-JEI8i3vZnZbhWs0ayMs5KnjlhYI=",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "cosmiconfig": "1.1.0",
+        "execa": "0.7.0",
+        "listr": "0.12.0",
+        "lodash.chunk": "4.2.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "staged-git-files": "0.0.4"
+      }
+    },
+    "listr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
+      "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.2.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.8",
+        "stream-to-observable": "0.1.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
+      "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
+    },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
+    },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.15.1",
+        "npm-path": "2.0.4",
+        "which": "1.3.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "prettier": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
+      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.8.tgz",
+      "integrity": "sha512-Bz7qou7VAIoGiglJZbzbXa4vpX5BmTTN2Dj/se6+SwADtw4SihqBIiEa7VmTXJ8pynvq0iFr5Gx9VLyye1rIxQ==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
+    "stream-to-observable": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
+      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
+    "tns-core-modules": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-3.4.1.tgz",
+      "integrity": "sha512-sz/yTmoW7WyDPpr4JEC+trlfiEI14X365jGF//tMCT/G6ISzANr43wc17fgbGH1UA1XbKzujbAl0xPNssRHVUA==",
+      "dev": true,
+      "requires": {
+        "tns-core-modules-widgets": "3.4.0"
+      }
+    },
+    "tns-core-modules-widgets": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-3.4.0.tgz",
+      "integrity": "sha512-WEtjDRTjjKB+C1NhY1CJSNyhK9DPCYzBgM+yKgq5AmphK/QdQEMAP1U2ttOv8yWWfsvLZGOnzyLCzcyeoG0Gfw==",
+      "dev": true
+    },
+    "tns-platform-declarations": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-3.4.1.tgz",
+      "integrity": "sha512-GCvUvmtZ2Nne9GIppYF5xzUQzYP+KF43R+ce9kFMT1erDP0I6thLrRkLEo8JgAYD7ukMqXAb80MlYMv/VDGSCw=="
+    },
+    "typescript": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -60,12 +60,13 @@
     "lint-staged": "^3.6.1",
     "prettier": "^1.4.4",
     "tns-core-modules": "^3.0.0",
-    "tns-platform-declarations": "^3.0.0",
     "typescript": "^2.2.2"
   },
   "peerDependencies": {
     "tns-core-modules": "^3.0.0"
   },
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "tns-platform-declarations": "^3.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -60,13 +60,12 @@
     "lint-staged": "^3.6.1",
     "prettier": "^1.4.4",
     "tns-core-modules": "^3.0.0",
+    "tns-platform-declarations": "^3.0.0",
     "typescript": "^2.2.2"
   },
   "peerDependencies": {
     "tns-core-modules": "^3.0.0"
   },
   "license": "MIT",
-  "dependencies": {
-    "tns-platform-declarations": "^3.0.0"
-  }
+  "dependencies": {}
 }

--- a/platforms/android/mukesh.image_processing.d.ts
+++ b/platforms/android/mukesh.image_processing.d.ts
@@ -1,0 +1,55 @@
+type Image = any;
+type Color = number;
+
+declare namespace com {
+  export namespace mukesh {
+    export namespace image_processing {
+      export class ImageProcessor {
+        doHighlightImage(image: Image, radius: number, color: Color): any;
+        doInvert(image: Image);
+        doGreyScale(image: Image);
+        doGamma(image: Image, red: number, green: number, blue: number);
+        doColorFilter(image: Image, red: number, green: number, blue: number);
+        createSepiaToningEffect(
+          image: Image,
+          depth: any,
+          red: number,
+          green: number,
+          blue: number
+        );
+        decreaseColorDepth(image: Image, bitOffset: any);
+        createContrast(image: Image, value);
+        createContrast(image: Image);
+        createContrast(image: Image, value);
+        applyGaussianBlur(image: Image);
+        createShadow(image: Image);
+        sharpen(image: Image, weight);
+        applyMeanRemoval(image: Image);
+        smooth(image: Image, value);
+        emboss(image: Image);
+        engrave(image: Image);
+        boost(image: Image, type, percent);
+        roundCorner(image: Image, round);
+        waterMark(
+          image: Image,
+          watermark: string,
+          location: android.graphics.Point,
+          color: number,
+          alpha: number,
+          size: number,
+          underline: boolean
+        );
+        flip(image: Image, type);
+        tintImage(image: Image, degree);
+        applyFleaEffect(image: Image);
+        applyBlackFilter(image: Image);
+        applySnowEffect(image: Image);
+        applyShadingFilter(image: Image, shadingColor: number);
+        applySaturationFilter(image: Image, level: number);
+        applyHueFilter(image: Image, level);
+        applyReflection(image: Image);
+        replaceColor(image: Image, fromColor: Color, targetColor: Color);
+      }
+    }
+  }
+}

--- a/references.d.ts
+++ b/references.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />
+/// <reference path="./node_modules/tns-platform-declarations/android.d.ts" />
+/// <reference path="./platforms/android/mukesh.image_processing.d.ts" />


### PR DESCRIPTION
This changeset is motivated by #4. It removes dependencies from `index.d.ts` to Android's `Point` class in favor of a custom `Point` declaration. It provides TypeScript declarations for `com.mukesh.image_processing.ImageProcessor`. This enables a clean and simple TypeScript build.